### PR TITLE
Add filter

### DIFF
--- a/src/Exception/FilterException.php
+++ b/src/Exception/FilterException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace BestIt\CommercetoolsODM\Exception;
+
+/**
+ * Exception for filter alerts
+ *
+ * @author Michel Chowanski <chowanski@bestit-online.de>
+ * @package BestIt\CommercetoolsODM\Exception
+ */
+class FilterException extends ResponseException
+{
+}

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BestIt\CommercetoolsODM\Filter;
+
+/**
+ * Interface FilterInterface
+ *
+ * @author Michel Chowanski <chowanski@bestit-online.de>
+ * @package BestIt\CommercetoolsODM
+ */
+interface FilterInterface
+{
+    /**
+     * Return filter key
+     *
+     * @return string
+     */
+    public function getKey(): string;
+
+    /**
+     * Apply filter on request
+     *
+     * @param mixed $request
+     *
+     * @return void
+     */
+    public function apply($request);
+}

--- a/src/Filter/FilterManager.php
+++ b/src/Filter/FilterManager.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace BestIt\CommercetoolsODM\Filter;
+
+use BestIt\CommercetoolsODM\Exception\FilterException;
+
+/**
+ * FilterManager for collecting and executing filters
+ *
+ * @author Michel Chowanski <chowanski@bestit-online.de>
+ * @package BestIt\CommercetoolsODM
+ */
+class FilterManager implements FilterManagerInterface
+{
+    /**
+     * The collected filters
+     *
+     * @var FilterInterface[]
+     */
+    private $filters = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add(FilterInterface $filter)
+    {
+        $this->filters[$filter->getKey()] = $filter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(string $key, $request)
+    {
+        if (!array_key_exists($key, $this->filters)) {
+            throw new FilterException(sprintf('Filter with key `%s` not found', $key));
+        }
+
+        $this->filters[$key]->apply($request);
+    }
+
+    /**
+     * Get all filters
+     *
+     * @return array
+     */
+    public function all(): array
+    {
+        return $this->filters;
+    }
+}

--- a/src/Filter/FilterManagerInterface.php
+++ b/src/Filter/FilterManagerInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BestIt\CommercetoolsODM\Filter;
+
+use BestIt\CommercetoolsODM\Exception\FilterException;
+
+/**
+ * FilterManagerInterface executing filters
+ *
+ * @author Michel Chowanski <chowanski@bestit-online.de>
+ * @package BestIt\CommercetoolsODM
+ */
+interface FilterManagerInterface
+{
+    /**
+     * Add filter
+     *
+     * @param FilterInterface $filter
+     *
+     * @return void
+     */
+    public function add(FilterInterface $filter);
+
+    /**
+     * Apply filter
+     *
+     * @param string $key
+     * @param mixed $request
+     *
+     * @return void
+     * @throws FilterException
+     */
+    public function apply(string $key, $request);
+}

--- a/src/Helper/FilterManagerAwareTrait.php
+++ b/src/Helper/FilterManagerAwareTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace BestIt\CommercetoolsODM\Helper;
+
+use BestIt\CommercetoolsODM\Filter\FilterManagerInterface;
+
+/**
+ * Getter and setter for filter manager
+ * @package BestIt\CommercetoolsODM\Helper
+ */
+trait FilterManagerAwareTrait
+{
+    /**
+     * The used filter manager
+     *
+     * @var FilterManagerInterface
+     */
+    private $filterManager;
+
+    /**
+     * Returns the used document manager
+     *
+     * @return FilterManagerInterface
+     */
+    public function getFilterManager(): FilterManagerInterface
+    {
+        return $this->filterManager;
+    }
+
+    /**
+     * Sets the used filter manager
+     *
+     * @param FilterManagerInterface $filterManager
+     *
+     * @return $this
+     */
+    public function setFilterManager(FilterManagerInterface $filterManager)
+    {
+        $this->filterManager = $filterManager;
+
+        return $this;
+    }
+}

--- a/src/Model/DefaultRepository.php
+++ b/src/Model/DefaultRepository.php
@@ -5,7 +5,9 @@ namespace BestIt\CommercetoolsODM\Model;
 use BadMethodCallException;
 use BestIt\CommercetoolsODM\DocumentManagerInterface;
 use BestIt\CommercetoolsODM\Exception\APIException;
+use BestIt\CommercetoolsODM\Filter\FilterManagerInterface;
 use BestIt\CommercetoolsODM\Helper\DocumentManagerAwareTrait;
+use BestIt\CommercetoolsODM\Helper\FilterManagerAwareTrait;
 use BestIt\CommercetoolsODM\Helper\QueryHelperAwareTrait;
 use BestIt\CommercetoolsODM\Mapping\ClassMetadataInterface;
 use BestIt\CommercetoolsODM\Repository\ObjectRepository;
@@ -34,7 +36,10 @@ use UnexpectedValueException;
  */
 class DefaultRepository implements ObjectRepository
 {
-    use DocumentManagerAwareTrait, QueryHelperAwareTrait, PoolAwareTrait;
+    use DocumentManagerAwareTrait;
+    use QueryHelperAwareTrait;
+    use PoolAwareTrait;
+    use FilterManagerAwareTrait;
 
     /**
      * Should the expand cache be cleared after the query.
@@ -55,22 +60,32 @@ class DefaultRepository implements ObjectRepository
     private $metdata = null;
 
     /**
+     * Filters
+     * @var string[]
+     */
+    private $filters = [];
+
+    /**
      * DefaultRepository constructor.
+     *
      * @param ClassMetadataInterface $metadata
      * @param DocumentManagerInterface $documentManager
      * @param QueryHelper $queryHelper
+     * @param FilterManagerInterface $filterManager
      * @param PoolInterface|null $pool
      */
     public function __construct(
         ClassMetadataInterface $metadata,
         DocumentManagerInterface $documentManager,
         QueryHelper $queryHelper,
+        FilterManagerInterface $filterManager,
         PoolInterface $pool = null
     ) {
         $this
             ->setDocumentManager($documentManager)
             ->setMetdata($metadata)
-            ->setQueryHelper($queryHelper);
+            ->setQueryHelper($queryHelper)
+            ->setFilterManager($filterManager);
 
         if ($pool) {
             $this->setPool($pool);
@@ -165,6 +180,10 @@ class DefaultRepository implements ObjectRepository
             });
         }
 
+        foreach($this->filters as $filterKey) {
+            $this->getFilterManager()->apply($filterKey, $request);
+        }
+
         return $request;
     }
 
@@ -183,6 +202,10 @@ class DefaultRepository implements ObjectRepository
         $request = $this->getDocumentManager()->createRequest($objectClass, $queryType, ...$parameters);
 
         $this->addExpandsToRequest($request);
+
+        foreach($this->filters as $filterKey) {
+            $this->getFilterManager()->apply($filterKey, $request);
+        }
 
         return $request;
     }
@@ -496,6 +519,16 @@ class DefaultRepository implements ObjectRepository
     protected function setMetdata(ClassMetadataInterface $metdata): DefaultRepository
     {
         $this->metdata = $metdata;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filter(string... $filters): ObjectRepository
+    {
+        $this->filters = $filters;
 
         return $this;
     }

--- a/src/Repository/ObjectRepository.php
+++ b/src/Repository/ObjectRepository.php
@@ -93,4 +93,11 @@ interface ObjectRepository extends BasicInterface
      * @return ObjectRepository
      */
     public function setExpands(array $expands, $clearAfterwards = false): ObjectRepository;
+
+    /**
+     * Apply filters
+     * @param string[] ...$filters
+     * @return ObjectRepository
+     */
+    public function filter(string... $filters): ObjectRepository;
 }

--- a/src/RepositoryFactory.php
+++ b/src/RepositoryFactory.php
@@ -2,6 +2,8 @@
 
 namespace BestIt\CommercetoolsODM;
 
+use BestIt\CommercetoolsODM\Filter\FilterManagerInterface;
+use BestIt\CommercetoolsODM\Helper\FilterManagerAwareTrait;
 use BestIt\CommercetoolsODM\Mapping\ClassMetadataInterface;
 use BestIt\CommercetoolsODM\Model\DefaultRepository;
 use BestIt\CTAsyncPool\PoolAwareTrait;
@@ -17,6 +19,7 @@ use Doctrine\Common\Persistence\ObjectRepository;
 class RepositoryFactory implements RepositoryFactoryInterface
 {
     use PoolAwareTrait;
+    use FilterManagerAwareTrait;
 
     /**
      * The default repository for this factory.
@@ -24,8 +27,16 @@ class RepositoryFactory implements RepositoryFactoryInterface
      */
     const DEFAULT_REPOSITORY = DefaultRepository::class;
 
-    public function __construct(PoolInterface $pool = null)
+    /**
+     * RepositoryFactory constructor.
+     *
+     * @param FilterManagerInterface $filterManager
+     * @param PoolInterface|null $pool
+     */
+    public function __construct(FilterManagerInterface $filterManager, PoolInterface $pool = null)
     {
+        $this->setFilterManager($filterManager);
+
         if ($pool) {
             $this->setPool($pool);
         }
@@ -47,6 +58,12 @@ class RepositoryFactory implements RepositoryFactoryInterface
             $repository = $tmp;
         }
 
-        return new $repository($metadata, $documentManager, $documentManager->getQueryHelper(), $this->getPool());
+        return new $repository(
+            $metadata,
+            $documentManager,
+            $documentManager->getQueryHelper(),
+            $this->getFilterManager(),
+            $this->getPool()
+        );
     }
 }

--- a/tests/Exception/FilterExceptionTest.php
+++ b/tests/Exception/FilterExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BestIt\CommercetoolsODM\Tests\Exception;
+
+use BestIt\CommercetoolsODM\Exception\FilterException;
+use BestIt\CommercetoolsODM\Exception\ResponseException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class FilterExceptionTest
+ *
+ * @author Michel Chowanski <chowanski@bestit-online.de>
+ * @package BestIt\CommercetoolsODM\Tests\Exception
+ */
+class FilterExceptionTest extends TestCase
+{
+    /**
+     * Test extands base exception
+     *
+     * @return void
+     */
+    public function testExtends()
+    {
+        static::assertInstanceOf(ResponseException::class, new FilterException());
+    }
+}

--- a/tests/Filter/FilterManagerTest.php
+++ b/tests/Filter/FilterManagerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace BestIt\CommercetoolsODM\Tests\Filter;
+
+use BestIt\CommercetoolsODM\Exception\FilterException;
+use BestIt\CommercetoolsODM\Filter\FilterInterface;
+use BestIt\CommercetoolsODM\Filter\FilterManager;
+use BestIt\CommercetoolsODM\Filter\FilterManagerInterface;
+use Commercetools\Core\Request\AbstractApiRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class FilterManagerTest
+ *
+ * @author Michel Chowanski <chowanski@bestit-online.de>
+ * @package BestIt\CommercetoolsODM\Tests\Filter
+ */
+class FilterManagerTest extends TestCase
+{
+    /**
+     * The filter manager
+     *
+     * @var FilterManager
+     */
+    private $fixture;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->fixture = new FilterManager();
+    }
+
+    /**
+     * Test that manager implement the interface
+     *
+     * @return void
+     */
+    public function testImplementInterface()
+    {
+        static::assertInstanceOf(FilterManagerInterface::class, $this->fixture);
+    }
+
+    /**
+     * Test add and get filter
+     *
+     * @return void
+     */
+    public function testAddFilter()
+    {
+        $filter = $this->createMock(FilterInterface::class);
+        $filter
+            ->expects(static::once())
+            ->method('getKey')
+            ->willReturn('foo');
+
+        $this->fixture->add($filter);
+        static::assertSame($filter, $this->fixture->all()['foo']);
+    }
+
+    /**
+     * Test apply filter
+     *
+     * @return void
+     */
+    public function testApply()
+    {
+        $request = $this->createMock(AbstractApiRequest::class);
+
+        $filter = $this->createMock(FilterInterface::class);
+        $filter
+            ->expects(static::once())
+            ->method('getKey')
+            ->willReturn('foo');
+
+        $filter
+            ->expects(static::once())
+            ->method('apply')
+            ->with($request);
+
+        $this->fixture->add($filter);
+
+        $this->fixture->apply('foo', $request);
+    }
+
+    /**
+     * Test that filter not found
+     *
+     * @return void
+     */
+    public function testFilterNotFound()
+    {
+        $this->expectException(FilterException::class);
+
+        $request = $this->createMock(AbstractApiRequest::class);
+
+        $filter = $this->createMock(FilterInterface::class);
+        $filter
+            ->expects(static::once())
+            ->method('getKey')
+            ->willReturn('foo');
+
+        $filter
+            ->expects(static::never())
+            ->method('apply');
+
+        $this->fixture->add($filter);
+
+        $this->fixture->apply('bar', $request);
+    }
+}

--- a/tests/Helper/FilterManagerAwareTraitTest.php
+++ b/tests/Helper/FilterManagerAwareTraitTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace BestIt\CommercetoolsODM\Tests\Helper;
+
+use BestIt\CommercetoolsODM\Filter\FilterManagerInterface;
+use BestIt\CommercetoolsODM\Helper\FilterManagerAwareTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class FilterManagerAwareTraitTest
+ *
+ * @author Michel Chowanski <chowanski@bestit-online.de>
+ * @package BestIt\CommercetoolsODM\Tests\Helper
+ */
+class FilterManagerAwareTraitTest extends TestCase
+{
+    /**
+     * The tested class
+     *
+     * @var FilterManagerAwareTrait
+     */
+    private $fixture = null;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->fixture = $this->getMockForTrait(FilterManagerAwareTrait::class);
+    }
+
+    /**
+     * Checks the getter and setter
+     *
+     * @return void
+     */
+    public function testGetAndSetRepository()
+    {
+        $this->assertSame(
+            $this->fixture,
+            $this->fixture->setFilterManager($mock = $this->createMock(FilterManagerInterface::class)),
+            'Fluent interface broken.'
+        );
+
+        $this->assertSame($mock, $this->fixture->getFilterManager(), 'Not saved.');
+    }
+}

--- a/tests/Repository/OrderRepositoryTest.php
+++ b/tests/Repository/OrderRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace BestIt\CommercetoolsODM\Tests\Repository;
 
 use BestIt\CommercetoolsODM\DocumentManagerInterface;
+use BestIt\CommercetoolsODM\Filter\FilterManagerInterface;
 use BestIt\CommercetoolsODM\Mapping\ClassMetadataInterface;
 use BestIt\CommercetoolsODM\Model\DefaultRepository;
 use BestIt\CommercetoolsODM\Repository\OrderRepository;
@@ -58,6 +59,7 @@ class OrderRepositoryTest extends TestCase
                 $metadata = static::createMock(ClassMetadataInterface::class),
                 $this->documentManager = static::createMock(DocumentManagerInterface::class),
                 static::createMock(QueryHelper::class),
+                static::createMock(FilterManagerInterface::class),
                 static::createMock(PoolInterface::class)
             ])
             ->getMock();

--- a/tests/Repository/TestRepositoryTrait.php
+++ b/tests/Repository/TestRepositoryTrait.php
@@ -3,6 +3,7 @@
 namespace BestIt\CommercetoolsODM\Tests\Repository;
 
 use BestIt\CommercetoolsODM\DocumentManagerInterface;
+use BestIt\CommercetoolsODM\Filter\FilterManagerInterface;
 use BestIt\CommercetoolsODM\Mapping\ClassMetadataInterface;
 use BestIt\CommercetoolsODM\Repository\ObjectRepository;
 use BestIt\CTAsyncPool\PoolInterface;
@@ -63,6 +64,7 @@ trait TestRepositoryTrait
             $this->createMock(ClassMetadataInterface::class),
             $this->documentManager = $this->createMock(DocumentManagerInterface::class),
             $this->createMock(QueryHelper::class),
+            $this->createMock(FilterManagerInterface::class),
             $this->createMock(PoolInterface::class)
         );
     }


### PR DESCRIPTION
**BREAKING CHANGE**

Leider ein Breaking Change - bietet aber dafür viel "Power". 
(DefaultRepository und die Factory haben einen weiteren Konstruktor Argument)

Die Problematik:
Wir haben an mehreren verschiedenen Stellen sync und async Product Requests. Diese benötigen immer wieder Standard Settings, damit der Shop an sich arbeiten kann. So muss an jeder Request beispielweise `->setExpands(['masterVariant.attributes[*].value', 'productType'])` ausgeführt werden.

Im Zuge der kundenspezifischen Preise müssen nun auch zusätzlich bei jeder Product Request auch `->channel()`und `->currency()` ausgeführt werden. Da dies zur Zeit an keiner zentralen Stelle passieren (kann), müssten bzw. werden also die drei Funktionen in jeder Klasse ausgeführt, die eine Produkt Request abfeuert. Für die Channel Findung wird des weiteren auch ein Service benötigt. So muss jede Klasse die Produkt Requests abfeuert zusätzlich auch den neuen Service für Channels einbinden. Das ist einfach too much. 

Daher verschiedene Lösungen ausprobiert und geprüft. Diese hier empfinde ich am einfachsten und sinnvollsten. Dabei orientiere ich mich ein wenig an: http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/filters.html

Ich definiere Filter die mit der Request entsprechende Aktionen durchführt. Das hat den Vorteil, dass dies ohne weiteren Service in den einzelnen Klassen auskommt, ich quasi alles mit der Request machen kann und dennoch penibel für jede Query andere Filter anwenden kann und somit flexibel bin. Wie dies genau funktioniert ist in der README des Bundle's zu lesen. Dort ist ebenfalls ein PR offen.

README: https://github.com/migo315/commercetools-odm-bundle/blob/feature/add-filter/README.md