### PR TITLE
Remove legacy support for commercetools php sdk < version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^7.0",
         "commercetools/commons": "^0.2",
-        "commercetools/php-sdk": "^1.4 || ^2.0",
+        "commercetools/php-sdk": "^2.0",
         "ext-intl": "^1.1",
         "doctrine/common": "^2.6",
         "bestit/commercetools-async-pool": "^2 || ^3",


### PR DESCRIPTION
Some implementations need php sdk version > 2.