### PR TITLE
Fix bug in handling external prices.

### DIFF
--- a/src/ActionBuilder/Cart/AddLineItem.php
+++ b/src/ActionBuilder/Cart/AddLineItem.php
@@ -65,7 +65,7 @@ class AddLineItem extends ActionBuilderAbstract
         }
 
         if ((array_key_exists('priceMode', $changedValue) && ($changedValue['priceMode'] === 'ExternalPrice'))) {
-            $cartAddLineItemAction['externalPrice'] = $changedValue['price'];
+            $cartAddLineItemAction['externalPrice'] = $changedValue['price']['value'];
         }
 
         $action = CartAddLineItemAction::fromArray($cartAddLineItemAction);

--- a/tests/ActionBuilder/Cart/AddLineItemTest.php
+++ b/tests/ActionBuilder/Cart/AddLineItemTest.php
@@ -116,8 +116,10 @@ class AddLineItemTest extends TestCase
 
         $value = [
             'price' => [
-                'currencyCode' => $currency = 'EUR',
-                'centAmount' => $centAmount = 50000,
+                'value' => [
+                    'currencyCode' => $currency = 'EUR',
+                    'centAmount' => $centAmount = 50000,
+                ]
             ],
             'priceMode' => 'ExternalPrice',
             'productId' => '444',


### PR DESCRIPTION
External prices use a money object and prices use an price object. So we have to use the money object of the price instead.