### PR TITLE
Adding paginator for find by queries of object repositories.

### DIFF
--- a/src/Pagination/FindByPaginator.php
+++ b/src/Pagination/FindByPaginator.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BestIt\CommercetoolsODM\Pagination;
+
+use BestIt\CommercetoolsODM\RepositoryAwareTrait;
+use Commercetools\Core\Model\Common\Resource;
+use BestIt\CommercetoolsODM\Repository\ObjectRepository;
+use \Generator;
+use \IteratorAggregate;
+use function sprintf;
+use function count;
+
+/**
+ * Paginator for object repositories.
+ *
+ * @author Tim Kellner <tim.kellner@bestit-online.de>
+ * @package BestIt\CommercetoolsODM\Pagination
+ */
+class FindByPaginator implements IteratorAggregate
+{
+    use RepositoryAwareTrait;
+
+    /**
+     * Default limit for commercetools queries.
+     *
+     * @var int DEFAULT_PAGE_SIZE
+     */
+    const DEFAULT_PAGE_SIZE = 20;
+
+    /**
+     * Used filter criteria.
+     *
+     * @var array $criteria
+     */
+    private $criteria;
+
+    /**
+     * The used page size.
+     *
+     * @var int $pageSize
+     */
+    private $pageSize;
+
+    /**
+     * The last queried id.
+     *
+     * @var string|null
+     */
+    private $lastId;
+
+    /**
+     * FindByPaginator constructor.
+     *
+     * @param ObjectRepository $repository Repository which is used for queries.
+     * @param array $criteria The filter criteria.
+     * @param int $pageSize Used page size. Default value is 20.
+     */
+    public function __construct(
+        ObjectRepository $repository,
+        array $criteria = [],
+        int $pageSize = self::DEFAULT_PAGE_SIZE
+    ) {
+        $this->setRepository($repository);
+        $this->criteria = $criteria;
+        $this->pageSize = $pageSize;
+    }
+
+    /**
+     * Get iterator to walk all elements.
+     *
+     * @return Generator
+     */
+    public function getIterator(): Generator
+    {
+        do {
+            $criteria = $this->criteria;
+
+            if ($this->lastId) {
+                $criteria[] = sprintf('id > "%s"', $this->lastId);
+            }
+
+            /**
+             * @var Resource[] $elements
+             */
+            $elements = $this->repository->findBy($criteria, ['id' => 'ASC'], $this->pageSize);
+            $count = count($elements);
+
+            foreach ($elements as $element) {
+                $this->lastId = $element->getId();
+                yield $element;
+            }
+        } while ($count === $this->pageSize);
+    }
+}

--- a/tests/Pagination/FindByPaginatorTest.php
+++ b/tests/Pagination/FindByPaginatorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BestIt\CommercetoolsODM\Tests\Pagination;
+
+use BestIt\CommercetoolsODM\Pagination\FindByPaginator;
+use Commercetools\Core\Model\Customer\Customer;
+use BestIt\CommercetoolsODM\Repository\ObjectRepository;
+use function iterator_to_array;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the FindByPaginator.
+ *
+ * @author Tim Kellner <tim.kellner@bestit-online.de>
+ * @package BestIt\CommercetoolsODM\Tests\Pagination
+ */
+class FindByPaginatorTest extends TestCase
+{
+    /**
+     * Test that paginator works properly.
+     *
+     * @return void
+     */
+    public function testPagination()
+    {
+        $fixture = new FindByPaginator(
+            $repository = $this->createMock(ObjectRepository::class),
+            $criteria = ['TEST = TEST'],
+            $pageSize = 3
+        );
+
+        $repository
+            ->method('findBy')
+            ->withConsecutive(
+                [['TEST = TEST']],
+                [['TEST = TEST', 'id > "A3"']],
+                [['TEST = TEST', 'id > "B6"']]
+            )
+            ->willReturnOnConsecutiveCalls(
+                [
+                    $element1 = Customer::of()->setId('A1'),
+                    $element2 = Customer::of()->setId('A2'),
+                    $element3 = Customer::of()->setId('A3')
+                ],
+                [
+                    $element4 = Customer::of()->setId('B4'),
+                    $element5 = Customer::of()->setId('B5'),
+                    $element6 = Customer::of()->setId('B6')
+                ],
+                [
+                    $element7 = Customer::of()->setId('C7'),
+                    $element8 = Customer::of()->setId('C8')
+                ]
+            );
+
+        $elements = iterator_to_array($fixture->getIterator());
+
+        self::assertCount(8, $elements);
+        self::assertSame($element1, $elements[0]);
+        self::assertSame($element2, $elements[1]);
+        self::assertSame($element3, $elements[2]);
+        self::assertSame($element4, $elements[3]);
+        self::assertSame($element5, $elements[4]);
+        self::assertSame($element6, $elements[5]);
+        self::assertSame($element7, $elements[6]);
+        self::assertSame($element8, $elements[7]);
+    }
+}


### PR DESCRIPTION
This PR add a paginator which can be used to query more than 500 elements (maximum limit of commercetools api). 