### PR TITLE
Fix problem with wrong date time creation.

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -963,7 +963,7 @@ class UnitOfWork implements UnitOfWorkInterface
                 break;
 
             case 'dateTime':
-                $returnValue = (new DateTimeDecorator($value))->getDateTime();
+                $returnValue = $value === null ? null : (new DateTimeDecorator($value))->getDateTime();
                 break;
 
             case 'int':


### PR DESCRIPTION
The getDateTime of the DateTimeDecorator returns now if null is applied to the constructor. This change directly return null instead of the wrong date time object.