### PR TITLE
Add optional service repository for simpler repository handling

### DIFF
--- a/src/Repository/ServiceEntityRepository.php
+++ b/src/Repository/ServiceEntityRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace BestIt\CommercetoolsODM\Repository;
+
+use BestIt\CommercetoolsODM\DocumentManagerInterface;
+use BestIt\CommercetoolsODM\Filter\FilterManagerInterface;
+use BestIt\CommercetoolsODM\Model\DefaultRepository;
+
+/**
+ * Optional DefaultRepository base class with a simplified constructor (for autowiring).
+ *
+ * To use in your class, inject the "document manager" and "filter manager" service and call
+ * the parent constructor. For example:
+ *
+ * class YourEntityRepository extends ServiceEntityRepository
+ * {
+ *     public function __construct(DocumentManagerInterface $documentManager, FilterManagerInterface $filterManager)
+ *     {
+ *         parent::__construct($documentManager, $filterManager, YourEntity::class);
+ *     }
+ * }
+ *
+ * @author Michel Chowanski <michel.chowanski@bestit-online.de>
+ * @package BestIt\CommercetoolsODM\Repository
+ */
+class ServiceEntityRepository extends DefaultRepository
+{
+    /**
+     * ServiceEntityRepository constructor.
+     *
+     * @param DocumentManagerInterface $documentManager
+     * @param FilterManagerInterface $filterManager
+     * @param string $entityClass
+     */
+    public function __construct(
+        DocumentManagerInterface $documentManager,
+        FilterManagerInterface $filterManager,
+        string $entityClass
+    ) {
+        $this->setFilterManager($filterManager);
+        $metadata = $documentManager->getClassMetadata($entityClass);
+
+        parent::__construct(
+            $metadata,
+            $documentManager,
+            $documentManager->getQueryHelper(),
+            $this->getFilterManager()
+        );
+    }
+}

--- a/tests/Repository/ServiceEntityRepositoryTest.php
+++ b/tests/Repository/ServiceEntityRepositoryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BestIt\CommercetoolsODM\Tests\Repository;
+
+use BestIt\CommercetoolsODM\DocumentManagerInterface;
+use BestIt\CommercetoolsODM\Filter\FilterManagerInterface;
+use BestIt\CommercetoolsODM\Mapping\ClassMetadataInterface;
+use BestIt\CommercetoolsODM\Model\DefaultRepository;
+use BestIt\CommercetoolsODM\Repository\ServiceEntityRepository;
+use Commercetools\Commons\Helper\QueryHelper;
+use Commercetools\Core\Model\Cart\Cart;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the service entity repository
+ *
+ * @author Michel Chowanski <michel.chowanski@bestit-online.de>
+ * @package BestIt\CommercetoolsODM\Tests\Repository
+ */
+class ServiceEntityRepositoryTest extends TestCase
+{
+    /**
+     * Test that repository will be correct builded
+     *
+     * @return void
+     */
+    public function testConstruct()
+    {
+        $odm = $this->createMock(DocumentManagerInterface::class);
+        $filterManager = $this->createMock(FilterManagerInterface::class);
+
+        $odm
+            ->expects(static::once())
+            ->method('getClassMetadata')
+            ->with(Cart::class)
+            ->willReturn($meta = $this->createMock(ClassMetadataInterface::class));
+
+        $meta
+            ->expects(static::any())
+            ->method('getName')
+            ->willReturn(Cart::class);
+
+        $odm
+            ->expects(static::once())
+            ->method('getQueryHelper')
+            ->willReturn($queryHelper = new QueryHelper());
+
+        $repository = new ServiceEntityRepository($odm, $filterManager, Cart::class);
+
+        static::assertSame($filterManager, $repository->getFilterManager());
+        static::assertSame($queryHelper, $repository->getQueryHelper());
+        static::assertSame($odm, $repository->getDocumentManager());
+        static::assertSame(Cart::class, $repository->getClassName());
+    }
+
+    /**
+     * Test extends from default repository
+     *
+     * @return void
+     */
+    public function testExtends()
+    {
+        $odm = $this->createMock(DocumentManagerInterface::class);
+        $filterManager = $this->createMock(FilterManagerInterface::class);
+
+        $odm
+            ->expects(static::once())
+            ->method('getClassMetadata')
+            ->with(Cart::class)
+            ->willReturn($meta = $this->createMock(ClassMetadataInterface::class));
+
+        $odm
+            ->expects(static::once())
+            ->method('getQueryHelper')
+            ->willReturn($queryHelper = new QueryHelper());
+
+        $repository = new ServiceEntityRepository($odm, $filterManager, Cart::class);
+
+        static::assertInstanceOf(DefaultRepository::class, $repository);
+    }
+}


### PR DESCRIPTION
It's the implementation of the doctrine service entity repository just for our ODM.

This has some benefits:

1. You often need own repository methods. Because we cannot extend the default repository, we have to create a second repository which inject the default repository. With this implementation, we just work with one repository we can customize. 

2. You can use autowire.

3. You do not need factories and large services definition likes this (in best case you need no definitions and just work with autowire):
```
BestIt\CommercetoolsODM\Model\CategoryRepository:
        class: BestIt\CommercetoolsODM\Model\DefaultRepository
        factory: ["@best_it.commercetools_odm.manager", getRepository]
        arguments:
            - Commercetools\Core\Model\Category\Category

    BestIt\CommercetoolsODM\Model\ChannelRepository:
        class: BestIt\CommercetoolsODM\Model\DefaultRepository
        factory: ['@best_it.commercetools_odm.manager', getRepository]
        arguments:
            - Commercetools\Core\Model\Channel\Channel

    BestIt\CommercetoolsODM\Model\ProductTypeRepository:
        class: BestIt\CommercetoolsODM\Model\DefaultRepository
        factory: ['@best_it.commercetools_odm.manager', getRepository]
        arguments:
            - Commercetools\Core\Model\ProductType\ProductType

    BestIt\CommercetoolsODM\Model\CustomObjectRepository:
        class: BestIt\CommercetoolsODM\Model\DefaultRepository
        factory: ['@best_it.commercetools_odm.manager', getRepository]
        arguments:
            - Commercetools\Core\Model\CustomObject\CustomObject
```

It still optional. You can use it ... or the old way.