### PR TITLE
BICO-3421: Add workaround for wrong total price …

### DIFF
--- a/src/ActionBuilder/Cart/SetLineItemQuantity.php
+++ b/src/ActionBuilder/Cart/SetLineItemQuantity.php
@@ -9,6 +9,7 @@ use Commercetools\Core\Model\Cart\Cart;
 use Commercetools\Core\Model\Cart\LineItem;
 use Commercetools\Core\Request\AbstractAction;
 use Commercetools\Core\Request\Carts\Command\CartChangeLineItemQuantityAction;
+use Commercetools\Core\Request\Carts\Command\CartSetLineItemPriceAction;
 
 /**
  * Builds the action to change cart item quantity
@@ -72,6 +73,16 @@ class SetLineItemQuantity extends CartActionBuilder
         if (defined('Commercetools\Core\Model\Cart\LineItem::PRICE_MODE_EXTERNAL_PRICE')
             && $lineItem->getPriceMode() === LineItem::PRICE_MODE_EXTERNAL_PRICE
         ) {
+            // Fix for https://jira.commercetools.com/servicedesk/customer/portal/1/SUPPORT-5132
+            // Action must set BEFORE the quantity change action
+            $actions[] = CartSetLineItemPriceAction::fromArray([
+                'lineItemId' => $lineItemId,
+                'externalPrice' => $this->getCorrectPrice(
+                    $lineItem->getPrice()->toArray(),
+                    $changedValue['quantity']
+                )
+            ]);
+
             $changeLineItemQuantityAction['externalPrice'] = $this->getCorrectPrice(
                 $lineItem->getPrice()->toArray(),
                 $changedValue['quantity']

--- a/tests/ActionBuilder/Cart/SetLineItemQuantityTest.php
+++ b/tests/ActionBuilder/Cart/SetLineItemQuantityTest.php
@@ -69,10 +69,16 @@ class SetLineItemQuantityTest extends TestCase
             $oldData,
             $sourceObject
         );
-        
+
+        // Test needed price change action exists before quantity change
         self::assertArrayHasKey(0, $actions);
         self::assertSame($lineItemId, $actions[0]->get('lineItemId'));
-        self::assertSame($quantity, $actions[0]->get('quantity'));
         self::assertEquals($priceValue->toArray(), $actions[0]->get('externalPrice')->toArray());
+
+        // Test correct quantity and price change
+        self::assertArrayHasKey(1, $actions);
+        self::assertSame($lineItemId, $actions[1]->get('lineItemId'));
+        self::assertSame($quantity, $actions[1]->get('quantity'));
+        self::assertEquals($priceValue->toArray(), $actions[1]->get('externalPrice')->toArray());
     }
 }


### PR DESCRIPTION
… when quantity with external price changed.

We have to send two actions. One for the price and after that the one for the quantity change.
It's a workaround suggested by commerce tools.