### PR TITLE
Fix intl version to *

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "type": "lib",
     "require": {
         "php": "^7.0",
-        "ext-intl": "^1.1",
+        "ext-intl": "*",
         "commercetools/commons": "^0.2",
         "commercetools/php-sdk": "^2.6",
         "doctrine/common": "^2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "887c882055144b7eebde1e3bce53a1ff",
+    "content-hash": "cce1db2fd01fdf9d6baf8ffacdc84d9d",
     "packages": [
         {
             "name": "bestit/commercetools-async-pool",
@@ -2687,7 +2687,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.0",
-        "ext-intl": "^1.1",
+        "ext-intl": "*",
         "ext-fileinfo": "*"
     },
     "platform-dev": []


### PR DESCRIPTION
See: https://getcomposer.org/doc/01-basic-usage.md

> ext-<name> allows you to require PHP extensions (includes core extensions). Versioning can be quite inconsistent here, so it's often a good idea to set the constraint to *

I've currently problems installing ODM without `--ignore-platform-reqs` because intl version is different for PHP7.4