### PR TITLE
DEN-330 - Fix: ChangeAttributeOrder is triggered when attributes are removed but the order effectively remains the same

### DIFF
--- a/tests/ActionBuilder/ProductType/ChangeOrderOfAttributesTest.php
+++ b/tests/ActionBuilder/ProductType/ChangeOrderOfAttributesTest.php
@@ -95,7 +95,7 @@ class ChangeOrderOfAttributesTest extends TestCase
             $productType
         );
 
-        static::assertCount(1, $actions);
+        static::assertCount(0, $actions);
     }
 
     /**
@@ -179,7 +179,7 @@ class ChangeOrderOfAttributesTest extends TestCase
             $productType
         );
 
-        static::assertCount(1, $actions);
+        static::assertCount(0, $actions);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Ahmad El-Bardan <ahmad.el-bardan@bestit-online.de>