### PR TITLE
Cast all keys to string when removing enums since CommerceTools only expects strings and not integers

### DIFF
--- a/src/ActionBuilder/ProductType/ChangeLocalizedEnumValues.php
+++ b/src/ActionBuilder/ProductType/ChangeLocalizedEnumValues.php
@@ -133,6 +133,7 @@ class ChangeLocalizedEnumValues extends ProductTypeActionBuilder
 
         $allCurrentKeys = array_column($attribute['type']['values'], 'key');
         $removedKeys = array_values(array_diff(array_keys($oldValues), $allCurrentKeys));
+        $removedKeys = array_map('strval', $removedKeys);
 
         if (count($removedKeys) > 0) {
             $actions[] = ProductTypeRemoveEnumValuesAction::fromArray([

--- a/src/ActionBuilder/ProductType/ChangeLocalizedEnumValuesSet.php
+++ b/src/ActionBuilder/ProductType/ChangeLocalizedEnumValuesSet.php
@@ -133,6 +133,7 @@ class ChangeLocalizedEnumValuesSet extends ChangeLocalizedEnumValues
 
         $allCurrentKeys = array_column($attribute['type']['elementType']['values'], 'key');
         $removedKeys = array_values(array_diff(array_keys($oldValues), $allCurrentKeys));
+        $removedKeys = array_map('strval', $removedKeys);
 
         if (count($removedKeys) > 0) {
             $actions[] = ProductTypeRemoveEnumValuesAction::fromArray([

--- a/tests/ActionBuilder/ProductType/ChangeLocalizedEnumValuesSetTest.php
+++ b/tests/ActionBuilder/ProductType/ChangeLocalizedEnumValuesSetTest.php
@@ -19,7 +19,7 @@ use PHPUnit_Framework_MockObject_MockObject;
  * @author Michel Chowanski <michel.chowanski@bestit-online.de>
  * @package BestIt\CommercetoolsODM\Tests\ActionBuilder\ProductType
  */
-class ChangeLocalizedEnumValuesSetSetTest extends TestCase
+class ChangeLocalizedEnumValuesSetTest extends TestCase
 {
     use SupportTestTrait;
 
@@ -242,6 +242,7 @@ class ChangeLocalizedEnumValuesSetSetTest extends TestCase
                             'values' => [
                                 ['key' => 'foo', 'label' => ['de' => 'bar']],
                                 ['key' => 'denios', 'label' => ['de' => 'Denios']],
+                                ['key' => 999, 'label' => ['de' => 'foo']],
                             ]
                         ]
                     ]
@@ -263,7 +264,11 @@ class ChangeLocalizedEnumValuesSetSetTest extends TestCase
 
         static::assertCount(1, $actions);
         static::assertSame($attributeName, $action->getAttributeName());
-        static::assertEquals(['foo'], $action->getKeys());
+        static::assertEquals(['foo', '999'], $action->getKeys());
+
+        foreach ($action->getKeys() as $key) {
+            static::assertInternalType('string', $key, "Key {$key} is not a string");
+        }
     }
 
     /**

--- a/tests/ActionBuilder/ProductType/ChangeLocalizedEnumValuesTest.php
+++ b/tests/ActionBuilder/ProductType/ChangeLocalizedEnumValuesTest.php
@@ -225,6 +225,7 @@ class ChangeLocalizedEnumValuesTest extends TestCase
                         'values' => [
                             ['key' => 'foo', 'label' => ['de' => 'bar']],
                             ['key' => 'denios', 'label' => ['de' => 'Denios']],
+                            ['key' => 999, 'label' => ['de' => 'foo']],
                         ]
                     ]
                 ],
@@ -245,7 +246,11 @@ class ChangeLocalizedEnumValuesTest extends TestCase
 
         static::assertCount(1, $actions);
         static::assertSame($attributeName, $action->getAttributeName());
-        static::assertEquals(['foo'], $action->getKeys());
+        static::assertEquals(['foo', '999'], $action->getKeys());
+
+        foreach ($action->getKeys() as $key) {
+            static::assertInternalType('string', $key, "Key {$key} is not a string");
+        }
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Ahmad El-Bardan <ahmad.el-bardan@bestit-online.de>