### PR TITLE
DEN-743 - Fix: Logic to find the correct variant using the variant index

### DIFF
--- a/src/ActionBuilder/Product/AddPrices.php
+++ b/src/ActionBuilder/Product/AddPrices.php
@@ -48,7 +48,11 @@ class AddPrices extends PriceActionBuilder
         if ($variantType === 'masterVariant') {
             $variantId = 1;
         } else {
-            $variantId += 2;
+            $variantId = $this->findVariantIdByVariantIndex($sourceObject, $variantId);
+        }
+
+        if ($variantId === null) {
+            return [];
         }
 
         /** @var ProductData $productData */

--- a/src/ActionBuilder/Product/ChangePrices.php
+++ b/src/ActionBuilder/Product/ChangePrices.php
@@ -41,7 +41,7 @@ class ChangePrices extends PriceActionBuilder
         if ($variantType === 'masterVariant') {
             $variantId = 1;
         } else {
-            $variantId += 2;
+            $variantId = $this->findVariantIdByVariantIndex($sourceObject, $variantId);
         }
 
         $actions = [];

--- a/src/ActionBuilder/Product/PriceActionBuilder.php
+++ b/src/ActionBuilder/Product/PriceActionBuilder.php
@@ -12,6 +12,8 @@ namespace BestIt\CommercetoolsODM\ActionBuilder\Product;
  */
 abstract class PriceActionBuilder extends ProductActionBuilder
 {
+    use VariantIdFinderTrait;
+
     /**
      * A PCRE to match the hierarchical field path without delimiter.
      *

--- a/src/ActionBuilder/Product/RemovePrices.php
+++ b/src/ActionBuilder/Product/RemovePrices.php
@@ -34,12 +34,12 @@ class RemovePrices extends PriceActionBuilder
         array $oldData,
         $sourceObject
     ): array {
-        list(, $dataId, $variantType, $variantId) = $this->getLastFoundMatch();
+        list(, $dataId, $variantType, $variantIndex) = $this->getLastFoundMatch();
 
         if ($variantType === 'masterVariant') {
             $variantId = 1;
         } else {
-            $variantId += 2;
+            $variantId = $this->findVariantIdByVariantIndex($sourceObject, $variantIndex);
         }
 
         /** @var ProductData $productData */
@@ -55,9 +55,9 @@ class RemovePrices extends PriceActionBuilder
         $actions = [];
 
         if ($variantType === 'masterVariant') {
-            $oldPrices = $oldData['masterData'][$dataId][$variantType]['prices'];
+            $oldPrices = $oldData['masterData'][$dataId][$variantType]['prices'] ?? [];
         } else {
-            $oldPrices = $oldData['masterData'][$dataId][$variantType][$variantId - 2]['prices'];
+            $oldPrices = $oldData['masterData'][$dataId][$variantType][$variantIndex]['prices'] ?? [];
         }
 
         foreach ($oldPrices as $priceArray) {

--- a/src/ActionBuilder/Product/VariantIdFinderTrait.php
+++ b/src/ActionBuilder/Product/VariantIdFinderTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace BestIt\CommercetoolsODM\ActionBuilder\Product;
+
+use Commercetools\Core\Model\Product\Product;
+
+/**
+ * Finds the variant using the index from the variants array.
+ *
+ * @package BestIt\CommercetoolsODM\ActionBuilder\Product
+ */
+trait VariantIdFinderTrait
+{
+    /**
+     * @param Product $product
+     * @param string|int $variantIndex
+     *
+     * @return int|null
+     */
+    protected function findVariantIdByVariantIndex(Product $product, $variantIndex)
+    {
+        $variants = $product->getMasterData()->getCurrent()->getVariants()->toArray();
+
+        if (!isset($variants[$variantIndex])) {
+            return null;
+        }
+
+        return $variants[$variantIndex]['id'] ?? null;
+    }
+}

--- a/tests/ActionBuilder/Product/AddPricesTest.php
+++ b/tests/ActionBuilder/Product/AddPricesTest.php
@@ -50,7 +50,9 @@ class AddPricesTest extends TestCase
      */
     public function testCreateUpdateActionsWithChangesForAVariant()
     {
-        $this->fixture->setLastFoundMatch([uniqid(), 'staged', 'variants', 0]);
+        $this->fixture->setLastFoundMatch([uniqid(), 'staged', 'variants', $variantIndex = 0]);
+
+        $variantId = 2;
 
         $product = new Product();
 
@@ -62,6 +64,10 @@ class AddPricesTest extends TestCase
             ->setMasterVariant(new ProductVariant())
             ->setVariants($variants = new ProductVariantCollection())
             ->getMasterVariant();
+
+        $product
+            ->getMasterData()
+            ->setCurrent($product->getMasterData()->getStaged());
 
         $prices = new PriceCollection();
 
@@ -76,11 +82,11 @@ class AddPricesTest extends TestCase
         $variant = new ProductVariant();
 
         $variant
-            ->setId(2)
+            ->setId($variantId)
             ->setSku($sku = 'sku')
             ->setPrices($prices);
 
-        $variants->setAt(2, $variant);
+        $variants->setAt($variantIndex, $variant);
 
         $actions = $this->fixture->createUpdateActions(
             [
@@ -96,7 +102,7 @@ class AddPricesTest extends TestCase
         /** @var ProductAddPriceAction $action */
         static::assertCount(1, $actions, 'Wrong action count.');
         static::assertInstanceOf(ProductAddPriceAction::class, $action = $actions[0], 'Wrong action type.');
-        static::assertSame(2, $action->getVariantId(), 'Wrong variant id.');
+        static::assertSame($variantId, $action->getVariantId(), 'Wrong variant id.');
         static::assertSame($country, $action->getPrice()->getCountry(), 'Wrong country.');
     }
 

--- a/tests/ActionBuilder/Product/ChangePricesTest.php
+++ b/tests/ActionBuilder/Product/ChangePricesTest.php
@@ -88,12 +88,18 @@ class ChangePricesTest extends TestCase
             '',
             'staged',
             'variants',
-            0,
+            $variantIndex = 0,
         ]);
 
         $product = Product::fromArray([
             'masterData' => [
                 'staged' => [
+                    'masterVariant' => [
+                        'id' => 1,
+                    ],
+                    'variants' => [],
+                ],
+                'current' => [
                     'masterVariant' => [
                         'id' => 1,
                     ],

--- a/tests/ActionBuilder/Product/SetSKUTest.php
+++ b/tests/ActionBuilder/Product/SetSKUTest.php
@@ -37,10 +37,10 @@ class SetSKUTest extends TestCase
     public function getCreateAssertions(): array
     {
         return [
-            ['masterData/current/masterVariant/sku', false, 1],
-            ['masterData/staged/masterVariant/sku'],
-            ['masterData/current/variants/0/sku', false, 2],
-            ['masterData/current/variants/5/sku', false, 7],
+            ['masterData/current/masterVariant/sku', '', false, 1],
+            ['masterData/staged/masterVariant/sku', ''],
+            ['masterData/current/variants/0/sku', 0, false, 2],
+            ['masterData/current/variants/5/sku', 5, false, 7],
         ];
     }
 
@@ -83,12 +83,13 @@ class SetSKUTest extends TestCase
      * @dataProvider getCreateAssertions
      *
      * @param string $path
+     * @param string|int $variantIndex
      * @param bool $staged
      * @param int $variantId
      *
      * @return void
      */
-    public function testCreateUpdateActions(string $path, bool $staged = true, int $variantId = 1)
+    public function testCreateUpdateActions(string $path, $variantIndex, bool $staged = true, int $variantId = 1)
     {
         $this->fixture->supports($path, Product::class);
 
@@ -101,7 +102,7 @@ class SetSKUTest extends TestCase
                 'masterData' => [
                     'current' => [
                         'variants' => [
-                            [
+                            $variantIndex => [
                                 'id' => $variantId,
                             ],
                         ],


### PR DESCRIPTION
Previously the variant id was assumed to always be "+2" which may be incorrect when deleting&adding variants.